### PR TITLE
Add GitHub Actions workflow to deploy site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Automate building and publishing the static site to GitHub Pages. 
- Restrict deployments to the `master` branch to prevent accidental publishes from other branches. 
- Use a reproducible CI pipeline that installs dependencies and runs the existing build (`npm run build`).
- Leverage built-in GitHub Pages actions for artifact upload and deployment.

### Description
- Add ` .github/workflows/deploy.yml` which defines a two-job workflow (`build` and `deploy`).
- The workflow triggers on `push` to `master` and on manual `workflow_dispatch` and sets `contents: read`, `pages: write`, and `id-token: write` permissions. 
- The `build` job checks out code, sets up Node.js (`node-version: 20`), runs `npm ci` and `npm run build`, then uses `actions/configure-pages@v4` and `actions/upload-pages-artifact@v3` with `path: build`.
- The `deploy` job depends on `build`, uses `actions/deploy-pages@v4`, and targets the `github-pages` environment with a concurrency group for `pages`.

### Testing
- No automated tests were run for this change as the workflow has not been executed yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f66369e1c8321a69ce3d06d53d89f)